### PR TITLE
create pipelines by project tag

### DIFF
--- a/front/pages/index.vue
+++ b/front/pages/index.vue
@@ -404,9 +404,26 @@
               </b-tabs>
             </b-card>
           </b-tab>
+
+          <b-tab key="tab7" title="external services">
+            <div>
+              <b-table striped hover :items="tab7Data" :fields="tab7DataFields">
+                <template #cell(WebURL)="data">
+                  <b-button target="_blank" :href="data.item.WebURL+'/-/pipelines/new?var[BUILD]=true&var[NAMESPACE]='+infoModal.content.Namespace" variant="primary">Create Pipeline</b-button>
+                </template>
+                <template #cell(Name)="data">
+                  <b-link target="_blank" :href="data.item.WebURL">{{ data.item.Name }}</b-link>
+                </template>
+              </b-table>
+              <br />
+              <b-button @click="showTab(7, true, true)">Refresh</b-button>
+            </div>
+          </b-tab>
+
         </b-tabs>
       </b-card>
     </b-modal>
+    
 
     <div style="padding: 5px" v-if="!isBusy && items == null">
       <b-alert variant="warning" show>No available namespaces founded</b-alert>
@@ -506,6 +523,7 @@ export default {
       tab2Data: null,
       tab4Data: null,
       tab5Data: null,
+      tab7Data: null,
       debug_enabled: "unknown",
       debug_text: "",
       gitOrigin: "",
@@ -841,6 +859,24 @@ export default {
               }
               this.tab5Data = true;
             }
+            break;
+
+          case 7:
+            if (!force && this.tab7Data!=null) return;
+
+            const { result } = await this.$axios.$get(
+              this.makeAPICallUrl("getProjects")
+            );
+
+            if (result.ExecCode) {
+              throw result;
+            }
+            this.tab7DataFields = [
+              { key: 'Name', label: 'Service'},
+              { key: 'Description', label: 'Description' },
+              { key: 'WebURL', label: 'Options' },
+            ]
+            this.tab7Data = result
             break;
         }
       } catch (e) {

--- a/front/plugins/app.js
+++ b/front/plugins/app.js
@@ -59,3 +59,6 @@ Vue.component('b-dropdown', BDropdown)
 
 import { BDropdownItem } from 'bootstrap-vue'
 Vue.component('b-dropdown-item', BDropdownItem)
+
+import { BLink } from 'bootstrap-vue'
+Vue.component('b-link', BLink)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -71,6 +71,8 @@ var config = Type{
 
 	SystemNamespaces: flag.String("system.namespaces", getEnvDefault("SYSTEM_NAMESPACES", "^kube-system$"), ""),
 	SystemGitTags:    flag.String("system.gitTags", getEnvDefault("SYSTEM_GIT_TAGS", "^master$,^release-.*"), ""),
+
+	ExternalServicesTopic: flag.String("externalServicesTopic", getEnvDefault("EXTERNAL_SERVICES_TOPIC", "kubernetes-manager"), ""), //nolint:lll
 }
 
 type Type struct {
@@ -97,6 +99,7 @@ type Type struct {
 	MakeAPICallServer          *string `yaml:"makeApiCallServer"`
 	SystemNamespaces           *string `yaml:"systemNamespaces"`
 	SystemGitTags              *string `yaml:"systemGitTags"`
+	ExternalServicesTopic      *string `yaml:"externalServicesTopic"`
 }
 
 func Load() error {

--- a/pkg/web/getProjects.go
+++ b/pkg/web/getProjects.go
@@ -1,0 +1,108 @@
+/*
+Copyright paskal.maksim@gmail.com
+Licensed under the Apache License, Version 2.0 (the "License")
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"sort"
+
+	"github.com/maksim-paskal/kubernetes-manager/pkg/config"
+	logrushookopentracing "github.com/maksim-paskal/logrus-hook-opentracing"
+	logrushooksentry "github.com/maksim-paskal/logrus-hook-sentry"
+	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
+	log "github.com/sirupsen/logrus"
+	"github.com/xanzy/go-gitlab"
+)
+
+type getProjectsResult struct {
+	Name        string
+	Description string
+	WebURL      string
+}
+
+func getProjects(w http.ResponseWriter, r *http.Request) {
+	tracer := opentracing.GlobalTracer()
+	spanCtx, _ := tracer.Extract(opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(r.Header))
+	span := tracer.StartSpan("getPods", ext.RPCServerOption(spanCtx))
+
+	defer span.Finish()
+
+	git, err := gitlab.NewClient(*config.Get().GitlabToken, gitlab.WithBaseURL(*config.Get().GitlabURL))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		log.
+			WithError(err).
+			WithField(logrushookopentracing.SpanKey, span).
+			WithFields(logrushooksentry.AddRequest(r)).
+			Error()
+
+		return
+	}
+
+	projects, _, err := git.Projects.ListProjects(&gitlab.ListProjectsOptions{
+		Topic: config.Get().ExternalServicesTopic,
+	})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		log.
+			WithError(err).
+			WithField(logrushookopentracing.SpanKey, span).
+			WithFields(logrushooksentry.AddRequest(r)).
+			Error()
+
+		return
+	}
+
+	type ResultType struct {
+		Result []getProjectsResult `json:"result"`
+	}
+
+	result := ResultType{}
+
+	result.Result = make([]getProjectsResult, len(projects))
+
+	for i, project := range projects {
+		result.Result[i].Name = project.NameWithNamespace
+		result.Result[i].Description = project.Description
+		result.Result[i].WebURL = project.WebURL
+	}
+
+	sort.SliceStable(result.Result, func(i, j int) bool {
+		return result.Result[i].Name < result.Result[j].Name
+	})
+
+	js, err := json.Marshal(result)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		log.
+			WithError(err).
+			WithField(logrushookopentracing.SpanKey, span).
+			WithFields(logrushooksentry.AddRequest(r)).
+			Error()
+
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_, err = w.Write(js)
+
+	if err != nil {
+		log.
+			WithError(err).
+			WithField(logrushookopentracing.SpanKey, span).
+			WithFields(logrushooksentry.AddRequest(r)).
+			Error()
+	}
+}

--- a/pkg/web/web.go
+++ b/pkg/web/web.go
@@ -42,6 +42,8 @@ func GetHandler() *http.ServeMux {
 	mux.HandleFunc("/api/getPods", getPods)
 	mux.HandleFunc("/api/debug", getDebug)
 	mux.HandleFunc("/api/disableHPA", disableHPA)
+	mux.HandleFunc("/api/getProjects", getProjects)
+
 	// pprof
 	mux.HandleFunc("/debug/pprof/", pprof.Index)
 	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)


### PR DESCRIPTION
Added new external services tab, that selects all project with topic `kubernetes-manager` from GitlabAPI. You can run GitLab pipelines on selected branch

Added new flag `externalServicesTopic` to change topic name 