### PR TITLE
add webhooks to scale down AWS instances and databases

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/maksim-paskal/kubernetes-manager/pkg/config"
 	"github.com/maksim-paskal/kubernetes-manager/pkg/utils"
 	"github.com/maksim-paskal/kubernetes-manager/pkg/web"
+	"github.com/maksim-paskal/kubernetes-manager/pkg/webhook"
 	logrushookopentracing "github.com/maksim-paskal/logrus-hook-opentracing"
 	logrushooksentry "github.com/maksim-paskal/logrus-hook-sentry"
 	opentracing "github.com/opentracing/opentracing-go"
@@ -57,10 +58,6 @@ func main() {
 		log.WithError(err).Fatal()
 	}
 
-	if err = config.CheckConfig(); err != nil {
-		log.WithError(err).Fatal()
-	}
-
 	logLevel, err := log.ParseLevel(*config.Get().LogLevel)
 	if err != nil {
 		log.WithError(err).Fatal()
@@ -68,6 +65,14 @@ func main() {
 
 	log.SetLevel(logLevel)
 	log.SetReportCaller(true)
+
+	if err = config.CheckConfig(); err != nil {
+		log.WithError(err).Fatal()
+	}
+
+	if err = webhook.CheckConfig(); err != nil {
+		log.WithError(err).Fatal()
+	}
 
 	log.Debugf("Using config:\n%s", config.String())
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/maksim-paskal/kubernetes-manager
 go 1.18
 
 require (
+	github.com/aws/aws-sdk-go v1.44.45
 	github.com/maksim-paskal/logrus-hook-opentracing v0.0.1
 	github.com/maksim-paskal/logrus-hook-sentry v0.0.9
 	github.com/maksim-paskal/sluglify v0.0.8
@@ -36,6 +37,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.1 // indirect
 	github.com/imdario/mergo v0.3.10 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/moby/spdystream v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
+github.com/aws/aws-sdk-go v1.44.45 h1:E2i73X4QdVS0XrfX/aVPt/M0Su2IuJ7AFvAMtF0id1Q=
+github.com/aws/aws-sdk-go v1.44.45/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -211,6 +213,10 @@ github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.10 h1:6q5mVkdH/vYmqngx7kZQTjJ5HRsx+ImorDIEQ+beJgc=
 github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
+github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=

--- a/pkg/api/scaleALL.go
+++ b/pkg/api/scaleALL.go
@@ -1,0 +1,74 @@
+/*
+Copyright paskal.maksim@gmail.com
+Licensed under the Apache License, Version 2.0 (the "License")
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package api
+
+import (
+	"encoding/json"
+
+	"github.com/maksim-paskal/kubernetes-manager/pkg/types"
+	"github.com/maksim-paskal/kubernetes-manager/pkg/webhook"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+// ScaleALL scale namespace and process webhooks.
+func ScaleALL(ns string, replicas int32) error {
+	processWebhook := make(chan error)
+	processScale := make(chan error)
+
+	go func() {
+		eventType := types.EventStart
+		if replicas == 0 {
+			eventType = types.EventStop
+		}
+
+		processWebhook <- webhook.NewEvent(types.WebhookMessage{
+			Event:     eventType,
+			Namespace: getNamespace(ns),
+			Cluster:   getCluster(ns),
+		})
+	}()
+
+	go func() {
+		processScale <- ScaleNamespace(ns, replicas)
+	}()
+
+	type Result struct {
+		ErrProcessWebhook string
+		ErrProcessScale   string
+	}
+
+	result := Result{}
+	hasError := false
+
+	if err := <-processWebhook; err != nil {
+		hasError = true
+		result.ErrProcessWebhook = err.Error()
+	}
+
+	if err := <-processScale; err != nil {
+		hasError = true
+		result.ErrProcessScale = err.Error()
+	}
+
+	if hasError {
+		resultText, err := json.Marshal(result)
+		if err != nil {
+			log.WithError(err).Error("error while marshaling result")
+		}
+
+		return errors.New(string(resultText))
+	}
+
+	return nil
+}

--- a/pkg/batch/batch.go
+++ b/pkg/batch/batch.go
@@ -118,7 +118,7 @@ func scaleDownALL(rootSpan opentracing.Span) error {
 
 			log.Info("scaledown")
 
-			err = api.ScaleNamespace(ingress.Namespace, 0)
+			err = api.ScaleALL(ingress.Namespace, 0)
 			if err != nil {
 				log.WithError(err).Error()
 			}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -45,6 +45,8 @@ const (
 	LabelGitProjectOrigin = Namespace + "/git-project-origin"
 	LabelRegistryTag      = Namespace + "/registry-tag"
 	LabelSystemNamespace  = Namespace + "/system-namespace"
+	TagNamespace          = Namespace + "/namespace"
+	TagCluster            = Namespace + "/cluster"
 )
 
 type Links struct {
@@ -86,6 +88,13 @@ type ProjectTemplate struct {
 type NamespaceMeta struct {
 	Labels      map[string]string
 	Annotations map[string]string
+}
+
+type WebHook struct {
+	Provider  string
+	Config    interface{}
+	Cluster   string
+	Namespace string
 }
 
 //nolint:gochecknoglobals
@@ -146,6 +155,7 @@ type Type struct {
 	BatchSheduleTimezone       *string        `yaml:"batchSheduleTimezone"`
 	PodName                    *string        `yaml:"podName"`
 	PodNamespace               *string        `yaml:"podNamespace"`
+	WebHooks                   []WebHook      `yaml:"webhooks"`
 }
 
 func (t *Type) GetProjectTemplateByProjectID(projectID string) *ProjectTemplate {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1,0 +1,26 @@
+/*
+Copyright paskal.maksim@gmail.com
+Licensed under the Apache License, Version 2.0 (the "License")
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package types
+
+type Event string
+
+const (
+	EventStart Event = "start"
+	EventStop  Event = "stop"
+)
+
+type WebhookMessage struct {
+	Event     Event
+	Cluster   string
+	Namespace string
+}

--- a/pkg/web/scaleNamespace.go
+++ b/pkg/web/scaleNamespace.go
@@ -59,7 +59,7 @@ func scaleNamespace(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = api.ScaleNamespace(namespace[0], int32(replicasInt))
+	err = api.ScaleALL(namespace[0], int32(replicasInt))
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		log.

--- a/pkg/webhook/aws/README.md
+++ b/pkg/webhook/aws/README.md
@@ -1,0 +1,23 @@
+# Scaledown all databases and instances in the account
+
+To reduce monthly bill, this module can scale down AWS RDS and EC2 instances that linked to kubernetes namespace with evening namespace scaledown process.
+
+Add to you kubernetes-manager config:
+
+```yaml
+webhooks: 
+- provider: aws
+  config:
+    accesskeyid: accesskeyid
+    accesssecretkey: accesssecretkey
+    region: us-east-1
+  namespace: some-namespace
+  cluster: some-cluster
+```
+
+this will scale down (and scale up) all databases and instances in the account with tags
+
+```yaml
+kubernetes-manager/cluster: some-cluster
+kubernetes-manager/namespace: some-namespace
+```

--- a/pkg/webhook/aws/aws.go
+++ b/pkg/webhook/aws/aws.go
@@ -1,0 +1,270 @@
+/*
+Copyright paskal.maksim@gmail.com
+Licensed under the Apache License, Version 2.0 (the "License")
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package aws
+
+import (
+	"encoding/json"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
+	"github.com/maksim-paskal/kubernetes-manager/pkg/config"
+	"github.com/maksim-paskal/kubernetes-manager/pkg/types"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v3"
+)
+
+type providerConfig struct {
+	AccessKeyID     string
+	AccessSecretKey string
+	Region          string
+}
+
+type Provider struct {
+	config    providerConfig
+	sess      *session.Session
+	condition config.WebHook
+	message   types.WebhookMessage
+}
+
+func (provider *Provider) Init(condition config.WebHook, message types.WebhookMessage) error {
+	var err error
+
+	configBytes, err := yaml.Marshal(condition.Config)
+	if err != nil {
+		return errors.Wrap(err, "invalid condition config")
+	}
+
+	err = yaml.Unmarshal(configBytes, &provider.config)
+	if err != nil {
+		return errors.Wrap(err, "invalid config")
+	}
+
+	provider.condition = condition
+	provider.message = message
+
+	provider.sess, err = session.NewSession(&aws.Config{
+		Region: aws.String(provider.config.Region),
+		Credentials: credentials.NewStaticCredentials(
+			provider.config.AccessKeyID,
+			provider.config.AccessSecretKey,
+			"",
+		),
+	},
+	)
+	if err != nil {
+		return errors.Wrap(err, "error while creating session")
+	}
+
+	if len(provider.config.Region) == 0 {
+		return errors.New("region is not defined")
+	}
+
+	return nil
+}
+
+func (provider *Provider) Process() error {
+	processInstances := make(chan error)
+	processDatabases := make(chan error)
+
+	go func() {
+		processInstances <- provider.processInstances()
+	}()
+
+	go func() {
+		processDatabases <- provider.processDatabases()
+	}()
+
+	type Result struct {
+		ErrProcessInstances string
+		ErrProcessDatases   string
+	}
+
+	result := Result{}
+	hasError := false
+
+	if err := <-processInstances; err != nil {
+		hasError = true
+		result.ErrProcessInstances = err.Error()
+	}
+
+	if err := <-processDatabases; err != nil {
+		hasError = true
+		result.ErrProcessDatases = err.Error()
+	}
+
+	if hasError {
+		resultText, err := json.Marshal(result)
+		if err != nil {
+			log.WithError(err).Error("error while marshaling result")
+		}
+
+		return errors.New(string(resultText))
+	}
+
+	return nil
+}
+
+func (provider *Provider) processInstances() error {
+	svc := ec2.New(provider.sess, &aws.Config{Region: aws.String(provider.config.Region)})
+
+	params := &ec2.DescribeInstancesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name: aws.String("tag:" + config.TagCluster),
+				Values: []*string{
+					aws.String(provider.message.Cluster),
+				},
+			},
+			{
+				Name: aws.String("tag:" + config.TagNamespace),
+				Values: []*string{
+					aws.String(provider.message.Namespace),
+				},
+			},
+		},
+	}
+
+	log.Debug(params)
+
+	resp, err := svc.DescribeInstances(params)
+	if err != nil {
+		return errors.Wrap(err, "error while getting instances")
+	}
+
+	if len(resp.Reservations) == 0 {
+		return errors.New("reservations not found")
+	}
+
+	instances := make([]*string, 0)
+
+	for _, reservations := range resp.Reservations {
+		for _, instance := range reservations.Instances {
+			// exclude terminated instances
+			if *instance.State.Name != "shutting-down" && *instance.State.Name != "terminated" {
+				instances = append(instances, instance.InstanceId)
+			}
+		}
+	}
+
+	if len(instances) == 0 {
+		return errors.New("instances not found")
+	}
+
+	switch provider.message.Event {
+	case types.EventStart:
+		result, err := svc.StartInstances(&ec2.StartInstancesInput{
+			DryRun:      aws.Bool(false),
+			InstanceIds: instances,
+		})
+		if err != nil {
+			return errors.Wrap(err, "error while starting database")
+		}
+
+		log.Debug(result.String())
+	case types.EventStop:
+		result, err := svc.StopInstances(&ec2.StopInstancesInput{
+			DryRun:      aws.Bool(false),
+			InstanceIds: instances,
+		})
+		if err != nil {
+			return errors.Wrap(err, "error while stoping database")
+		}
+
+		log.Debug(result.String())
+	default:
+		log.Warn("unknown event " + provider.message.Event)
+	}
+
+	return nil
+}
+
+func (provider *Provider) processDatabases() error {
+	resources := resourcegroupstaggingapi.New(provider.sess, &aws.Config{Region: aws.String(provider.config.Region)})
+
+	// list databases by tags, rds.DescribeDBInstances do not use tags for filtering
+	dbs, err := resources.GetResources(&resourcegroupstaggingapi.GetResourcesInput{
+		ResourceTypeFilters: aws.StringSlice([]string{"rds:db"}),
+		TagFilters: []*resourcegroupstaggingapi.TagFilter{
+			{
+				Key:    aws.String(config.TagCluster),
+				Values: aws.StringSlice([]string{provider.message.Cluster}),
+			},
+			{
+				Key:    aws.String(config.TagNamespace),
+				Values: aws.StringSlice([]string{provider.message.Namespace}),
+			},
+		},
+	})
+	if err != nil {
+		return errors.Wrap(err, "error getting resources databases")
+	}
+
+	svc := rds.New(provider.sess, &aws.Config{Region: aws.String(provider.config.Region)})
+
+	for _, resource := range dbs.ResourceTagMappingList {
+		database, err := svc.DescribeDBInstances(&rds.DescribeDBInstancesInput{
+			DBInstanceIdentifier: resource.ResourceARN,
+		})
+		if err != nil {
+			return errors.Wrap(err, "error getting database")
+		}
+
+		status := database.DBInstances[0].DBInstanceStatus
+
+		switch provider.message.Event {
+		case types.EventStart:
+			// start instance only if it is stopped or inaccessible-encryption-credentials-recoverable
+			if *status != "stopped" && *status != "inaccessible-encryption-credentials-recoverable" {
+				log.Warn("database has invalid status=" + *status + " to start")
+
+				continue
+			}
+
+			result, err := svc.StartDBInstance(&rds.StartDBInstanceInput{
+				DBInstanceIdentifier: database.DBInstances[0].DBInstanceIdentifier,
+			})
+			if err != nil {
+				return errors.Wrap(err, "error while starting instances")
+			}
+
+			log.Debug(result.String())
+
+		case types.EventStop:
+			// stop instance only if it is available
+			if *status != "available" {
+				log.Warn("database has invalid status=" + *status + " to stop")
+
+				continue
+			}
+
+			result, err := svc.StopDBInstance(&rds.StopDBInstanceInput{
+				DBInstanceIdentifier: database.DBInstances[0].DBInstanceIdentifier,
+			})
+			if err != nil {
+				return errors.Wrap(err, "error while stoping instances")
+			}
+
+			log.Debug(result.String())
+
+		default:
+			log.Warn("unknown event " + provider.message.Event)
+		}
+	}
+
+	return nil
+}

--- a/pkg/webhook/aws/policy.json
+++ b/pkg/webhook/aws/policy.json
@@ -1,0 +1,14 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "tag:GetResources",
+        "ec2:*",
+        "rds:*"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -1,0 +1,81 @@
+/*
+Copyright paskal.maksim@gmail.com
+Licensed under the Apache License, Version 2.0 (the "License")
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package webhook
+
+import (
+	"github.com/maksim-paskal/kubernetes-manager/pkg/config"
+	"github.com/maksim-paskal/kubernetes-manager/pkg/types"
+	"github.com/maksim-paskal/kubernetes-manager/pkg/webhook/aws"
+	"github.com/pkg/errors"
+)
+
+// provider interface to process events.
+type Provider interface {
+	Init(config.WebHook, types.WebhookMessage) error
+	Process() error
+}
+
+// create new webbhok event.
+func NewEvent(message types.WebhookMessage) error {
+	for _, condition := range config.Get().WebHooks {
+		if condition.Cluster == message.Cluster && condition.Namespace == message.Namespace {
+			if err := processEvent(condition, message); err != nil {
+				return errors.Wrap(err, "error while processing event")
+			}
+		}
+	}
+
+	return nil
+}
+
+// test valid webhooks config.
+func CheckConfig() error {
+	for _, condition := range config.Get().WebHooks {
+		provider, err := NewProvider(condition.Provider)
+		if err != nil {
+			return errors.Wrap(err, "find valid provider")
+		}
+
+		// init provider with null message.
+		if err := provider.Init(condition, types.WebhookMessage{}); err != nil {
+			if err != nil {
+				return errors.Wrap(err, "find valid provider")
+			}
+		}
+	}
+
+	return nil
+}
+
+// process event.
+func processEvent(condition config.WebHook, message types.WebhookMessage) error {
+	provider, err := NewProvider(condition.Provider)
+	if err != nil {
+		return errors.Wrap(err, "find valid provider")
+	}
+
+	if err := provider.Init(condition, message); err != nil {
+		return errors.Wrap(err, "provider init error")
+	}
+
+	return errors.Wrap(provider.Process(), "provider processing error")
+}
+
+func NewProvider(provider string) (Provider, error) { //nolint:ireturn
+	switch provider {
+	case "aws":
+		return new(aws.Provider), nil
+	default:
+		return nil, errors.New("no provider was found " + provider)
+	}
+}


### PR DESCRIPTION
To reduce monthly bill, this change can scale down (scale up) AWS RDS and EC2 instances that linked to kubernetes namespace with scaling kubernetes namespace. 

Add to you kubernetes-manager config:
```yaml
webhooks: 
- provider: aws
  config:
    accesskeyid: accesskeyid
    accesssecretkey: accesssecretkey
    region: us-east-1
  namespace: some-namespace
  cluster: some-cluster
```

This will scale down (and scale up) all databases and instances in the account with kubernetes-manager tags

```yaml
kubernetes-manager/cluster: some-cluster
kubernetes-manager/namespace: some-namespace
```

Signed-off-by: Maksim Paskal <paskal.maksim@gmail.com>