### PR TITLE
manage remote servers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build:
 	git tag -d `git tag -l "kubernetes-manager-*"`
 	go run github.com/goreleaser/goreleaser@latest build --rm-dist --snapshot --skip-validate
 	mv ./dist/kubernetes-manager_linux_amd64_v1/kubernetes-manager ./kubernetes-manager
-	docker buildx build --pull --push --build-arg=APPVERSION=`git rev-parse --short HEAD` . -t $(image)
+	docker buildx build --platform=linux/amd64 --pull --push --build-arg=APPVERSION=`git rev-parse --short HEAD` . -t $(image)
 security-scan:
 	go run github.com/aquasecurity/trivy/cmd/trivy@latest fs --ignore-unfixed .
 security-check:

--- a/front/components/EnvironmentTabs.vue
+++ b/front/components/EnvironmentTabs.vue
@@ -10,6 +10,9 @@
       <li class="nav-item">
         <b-link class="nav-link" active-class="active" to="/all">all</b-link>
       </li>
+      <li class="nav-item">
+        <b-link class="nav-link" active-class="active" to="/remote-servers">remote servers</b-link>
+      </li>
     </ul>
   </div>
 </template>

--- a/front/components/RemoteList.vue
+++ b/front/components/RemoteList.vue
@@ -1,0 +1,95 @@
+<template>
+  <div>
+    <b-alert v-if="$fetchState.error" variant="danger" show>{{
+    $fetchState.error.message
+    }}</b-alert>
+    <b-alert v-if="this.errorText" variant="danger" show>{{
+    this.errorText
+    }}</b-alert>
+    <b-alert v-if="this.infoText" variant="info" show>{{
+    this.infoText
+    }}</b-alert>
+
+    <div v-if="$fetchState.pending || callIsLoading" style="padding: 50px" class="text-center">
+      <b-spinner style="width: 10rem; height: 10rem" variant="primary" />
+    </div>
+    <div v-else>
+      <div style="padding:10px">
+        <b-form-input v-model="tableFilter" autocomplete="off" placeholder="Type to Search" />
+      </div>
+      <b-table striped hover :fields="fields" :items="data" :filter="tableFilter">
+        <template v-slot:cell(Address)="row">
+          {{ row.item.IPv4 }}
+        </template>
+        <template v-slot:cell(Status)="row">
+          {{ row.item.Status }}
+          <div v-if="row.item.Status == 'Stoped'">
+            <b-button size="sm" variant="success" @click="serverAction(row,'power_on')">
+              Start
+            </b-button>
+          </div>
+        </template>
+        <template v-slot:cell(Actions)="row">
+          <b-button size="sm" variant="outline-primary" @click="showConfigDialog(row)">Local
+            configuration
+          </b-button>
+        </template>
+      </b-table>
+      <b-modal size="xl" centered id="bv-remote-servers-config-dialog" title="Local configuration" ok-only>
+        <h3>MacOS users</h3>
+        <CopyTextbox :text="darwinText" />
+        <br />
+        <h3>Linux users</h3>
+        <CopyTextbox :text="linuxText" />
+      </b-modal>
+    </div>
+  </div>
+</template>
+<script>
+export default {
+  mounted() {
+    this.tableFilter = this.user.user;
+  },
+  async fetch() {
+    const result = await fetch('/api/remote-servers');
+    if (result.ok) {
+      const data = await result.json();
+      this.data = data.Result
+    } else {
+      const text = await result.text();
+      throw Error(text);
+    }
+  },
+  data() {
+    return {
+      errorText: "",
+      infoText: "",
+      tableFilter: "",
+      fields: [
+        { key: "Name", sortable: false, class: "text-center" },
+        { key: "Address", sortable: false, class: "text-center" },
+        { key: "Status", sortable: false, class: "text-center" },
+        { key: "Actions", sortable: false, class: "col-deploy-service-text" },
+      ],
+      darwinText: "",
+      linuxText: "",
+      data: []
+    }
+  },
+  methods: {
+    showConfigDialog(row) {
+      this.darwinText = `sudo curl -sSL https://get.paskal-dev.com/local-dev-darwin.sh | sudo REMOTE_IP=${row.item.IPv4} sh`
+      this.linuxText = `sudo curl -sSL https://get.paskal-dev.com/local-dev-linux.sh | sudo REMOTE_IP=${row.item.IPv4} sh`
+
+      this.$bvModal.show('bv-remote-servers-config-dialog')
+    },
+    async serverAction(row, action) {
+      await this.callEndpoint('/api/make-remote-server-action', {
+        Cloud: row.item.Cloud,
+        ID: row.item.ID,
+        Action: action
+      }, true);
+    }
+  }
+}
+</script>

--- a/front/pages/remote-servers.vue
+++ b/front/pages/remote-servers.vue
@@ -1,0 +1,6 @@
+<template>
+  <div>
+    <b-spinner v-if="!this.user.user" variant="primary" />
+    <RemoteList v-else />
+  </div>
+</template>

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.0.0
 	github.com/aws/aws-sdk-go v1.44.86
 	github.com/gorilla/mux v1.8.0
+	github.com/hetznercloud/hcloud-go v1.35.3
 	github.com/maksim-paskal/logrus-hook-opentracing v0.0.1
 	github.com/maksim-paskal/logrus-hook-sentry v0.0.9
 	github.com/maksim-paskal/sluglify v0.0.8

--- a/go.sum
+++ b/go.sum
@@ -234,6 +234,8 @@ github.com/hashicorp/go-retryablehttp v0.7.1 h1:sUiuQAnLlbvmExtFQs72iFW/HXeUn8Z1
 github.com/hashicorp/go-retryablehttp v0.7.1/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hetznercloud/hcloud-go v1.35.3 h1:WCmFAhLRooih2QHAsbCbEdpIHnshQQmrPqsr3rHE1Ow=
+github.com/hetznercloud/hcloud-go v1.35.3/go.mod h1:mepQwR6va27S3UQthaEPGS86jtzSY9xWL1e9dyxXpgA=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/pkg/api/GetRemoteServers.go
+++ b/pkg/api/GetRemoteServers.go
@@ -1,0 +1,76 @@
+/*
+Copyright paskal.maksim@gmail.com
+Licensed under the Apache License, Version 2.0 (the "License")
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package api
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/hetznercloud/hcloud-go/hcloud"
+	"github.com/maksim-paskal/kubernetes-manager/pkg/client"
+	"github.com/maksim-paskal/kubernetes-manager/pkg/config"
+	"github.com/pkg/errors"
+)
+
+type GetRemoteServerItemStatus string
+
+const (
+	GetRemoteServerItemStatusRunning GetRemoteServerItemStatus = "Running"
+	GetRemoteServerItemStatusStoped  GetRemoteServerItemStatus = "Stoped"
+)
+
+type GetRemoteServerItem struct {
+	Cloud  string
+	ID     string
+	Name   string
+	Status GetRemoteServerItemStatus
+	IPv4   string
+	Labels map[string]string
+}
+
+var errNoHetznerCloudToken = errors.New("no hetzner cloud token, please set it in config file")
+
+// return all remote servers.
+func GetRemoteServers(ctx context.Context) ([]*GetRemoteServerItem, error) {
+	if len(config.Get().RemoteServer.HetznerToken) == 0 {
+		return nil, errNoHetznerCloudToken
+	}
+
+	hcloundClient := client.GetHcloudClient()
+
+	result := make([]*GetRemoteServerItem, 0)
+
+	servers, err := hcloundClient.Server.All(ctx)
+	if err != nil {
+		return result, errors.Wrap(err, "can not get servers")
+	}
+
+	for _, server := range servers {
+		status := GetRemoteServerItemStatusStoped
+
+		if server.Status == hcloud.ServerStatusRunning {
+			status = GetRemoteServerItemStatusRunning
+		}
+
+		result = append(result, &GetRemoteServerItem{
+			Cloud:  "hcloud",
+			ID:     strconv.Itoa(server.ID),
+			Name:   server.Name,
+			Status: status,
+			IPv4:   server.PublicNet.IPv4.IP.String(),
+			Labels: server.Labels,
+		})
+	}
+
+	return result, nil
+}

--- a/pkg/api/SetRemoteServerAction.go
+++ b/pkg/api/SetRemoteServerAction.go
@@ -1,0 +1,85 @@
+/*
+Copyright paskal.maksim@gmail.com
+Licensed under the Apache License, Version 2.0 (the "License")
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package api
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/maksim-paskal/kubernetes-manager/pkg/client"
+	"github.com/pkg/errors"
+)
+
+type SetRemoteServerStatusAction string
+
+const (
+	SetRemoteServerStatusPowerOn  SetRemoteServerStatusAction = "power_on"
+	SetRemoteServerStatusPowerOff SetRemoteServerStatusAction = "power_off"
+)
+
+func (a SetRemoteServerStatusAction) Validate() error {
+	if a == SetRemoteServerStatusPowerOn {
+		return nil
+	}
+
+	if a == SetRemoteServerStatusPowerOff {
+		return nil
+	}
+
+	return errors.New("unknown status")
+}
+
+type SetRemoteServerActionInput struct {
+	Cloud  string
+	ID     string
+	Action SetRemoteServerStatusAction
+}
+
+// return all remote servers.
+func SetRemoteServerAction(ctx context.Context, input SetRemoteServerActionInput) error {
+	if input.Cloud != "hcloud" {
+		return errors.New("cloud not supported")
+	}
+
+	if err := input.Action.Validate(); err != nil {
+		return errors.Wrapf(err, "error validate action %s", input.Action)
+	}
+
+	hcloundClient := client.GetHcloudClient()
+
+	id, err := strconv.Atoi(input.ID)
+	if err != nil {
+		return errors.New("can not parse id")
+	}
+
+	server, _, err := hcloundClient.Server.GetByID(ctx, id)
+	if err != nil {
+		return errors.Wrap(err, "can not get server")
+	}
+
+	if input.Action == SetRemoteServerStatusPowerOff {
+		_, _, err = hcloundClient.Server.Poweroff(ctx, server)
+		if err != nil {
+			return errors.Wrap(err, "can power off server")
+		}
+	}
+
+	if input.Action == SetRemoteServerStatusPowerOn {
+		_, _, err = hcloundClient.Server.Poweron(ctx, server)
+		if err != nil {
+			return errors.Wrap(err, "can power on server")
+		}
+	}
+
+	return nil
+}

--- a/pkg/api/execContainer.go
+++ b/pkg/api/execContainer.go
@@ -30,7 +30,7 @@ type ExecContainerResults struct {
 }
 
 // exec command in container
-// container must contains <pod>:<container.
+// @container must contains <pod>:<container>.
 func (e *Environment) ExecContainer(container string, command string) (*ExecContainerResults, error) {
 	containerInfo, err := types.NewContainerInfo(container)
 	if err != nil {

--- a/pkg/batch/batch.go
+++ b/pkg/batch/batch.go
@@ -101,6 +101,23 @@ func scaleDownALL(ctx context.Context, rootSpan opentracing.Span) error {
 		}(environment)
 	}
 
+	// scaledown servers
+	servers, err := api.GetRemoteServers(ctx)
+	if err != nil {
+		return errors.Wrap(err, "error listing servers")
+	}
+
+	for _, server := range servers {
+		err := api.SetRemoteServerAction(ctx, api.SetRemoteServerActionInput{
+			Cloud:  server.Cloud,
+			ID:     server.ID,
+			Action: api.SetRemoteServerStatusPowerOff,
+		})
+		if err != nil {
+			log.WithError(err).Errorf("error power off server %s", server.ID)
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/batch/utils.go
+++ b/pkg/batch/utils.go
@@ -43,9 +43,9 @@ func IsScaleDownActive(now time.Time) bool {
 }
 
 // check if scale down is active, namespace will be scaled if false, there is no scaledown if
-// if namespace created less than 60m
-// if last scale date less than 60m
-// if user ask to nodelay.
+// namespace created less than 60m
+// last scale date less than 60m
+// user ask to nodelay.
 func IsScaledownDelay(nowTime time.Time, environment *api.Environment) (bool, error) {
 	log := log.WithField("namespace", environment.Namespace)
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -13,6 +13,7 @@ limitations under the License.
 package client
 
 import (
+	"github.com/hetznercloud/hcloud-go/hcloud"
 	"github.com/maksim-paskal/kubernetes-manager/pkg/config"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -25,6 +26,7 @@ import (
 
 var (
 	gitlabClient *gitlab.Client
+	hcloudClient *hcloud.Client
 
 	clientsetCluster  map[string]*kubernetes.Clientset
 	restconfigCluster map[string]*rest.Config
@@ -72,6 +74,10 @@ func GetInclusterClientset() (*kubernetes.Clientset, error) {
 	return clientset, nil
 }
 
+func GetHcloudClient() *hcloud.Client {
+	return hcloudClient
+}
+
 func Init() error {
 	var (
 		err        error
@@ -115,6 +121,8 @@ func Init() error {
 		clientsetCluster[kubernetesEndpoints.Name] = clientset
 		restconfigCluster[kubernetesEndpoints.Name] = restconfig
 	}
+
+	hcloudClient = hcloud.NewClient(hcloud.WithToken(config.Get().RemoteServer.HetznerToken))
 
 	return nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -168,6 +168,10 @@ type Snapshot struct {
 	Ref       string
 }
 
+type RemoteServer struct {
+	HetznerToken string
+}
+
 //nolint:gochecknoglobals
 var config = Type{
 	ConfigPath: flag.String("config", os.Getenv("CONFIG"), "config"),
@@ -225,6 +229,7 @@ type Type struct {
 	PodNamespace               *string        `yaml:"podNamespace"`
 	WebHooks                   []WebHook      `yaml:"webhooks"`
 	Snapshots                  Snapshot       `yaml:"snapshots"`
+	RemoteServer               RemoteServer   `yaml:"remoteServer"`
 }
 
 func (t *Type) DeepCopy() *Type {

--- a/pkg/web/handlerAPI.go
+++ b/pkg/web/handlerAPI.go
@@ -168,6 +168,27 @@ func apiOperation(ctx context.Context, r *http.Request, operation string) (*Hand
 		}
 
 		result.Result = projectTypes
+	case "remote-servers":
+		remoteServers, err := api.GetRemoteServers(ctx)
+		if err != nil {
+			return result, err
+		}
+
+		result.Result = remoteServers
+	case "make-remote-server-action":
+		input := api.SetRemoteServerActionInput{}
+
+		err = json.Unmarshal(body, &input)
+		if err != nil {
+			return result, err
+		}
+
+		err := api.SetRemoteServerAction(ctx, input)
+		if err != nil {
+			return result, err
+		}
+
+		result.Result = "server status changed, press Refresh to view changes"
 	default:
 		return result, errors.Wrap(errNoComandFound, operation)
 	}

--- a/pkg/webhook/aws/aws.go
+++ b/pkg/webhook/aws/aws.go
@@ -142,7 +142,7 @@ func (provider *Provider) processInstances(ctx context.Context) error {
 
 	log.Debug(params)
 
-	resp, err := svc.DescribeInstancesWithContext(ctx, params) //nolint:contextcheck
+	resp, err := svc.DescribeInstancesWithContext(ctx, params)
 	if err != nil {
 		return errors.Wrap(err, "error while getting instances")
 	}
@@ -168,7 +168,7 @@ func (provider *Provider) processInstances(ctx context.Context) error {
 
 	switch provider.message.Event {
 	case types.EventStart:
-		result, err := svc.StartInstancesWithContext(ctx, &ec2.StartInstancesInput{ //nolint:contextcheck
+		result, err := svc.StartInstancesWithContext(ctx, &ec2.StartInstancesInput{
 			DryRun:      aws.Bool(false),
 			InstanceIds: instances,
 		})
@@ -178,7 +178,7 @@ func (provider *Provider) processInstances(ctx context.Context) error {
 
 		log.Debug(result.String())
 	case types.EventStop:
-		result, err := svc.StopInstancesWithContext(ctx, &ec2.StopInstancesInput{ //nolint:contextcheck
+		result, err := svc.StopInstancesWithContext(ctx, &ec2.StopInstancesInput{
 			DryRun:      aws.Bool(false),
 			InstanceIds: instances,
 		})
@@ -218,7 +218,7 @@ func (provider *Provider) processDatabases(ctx context.Context) error {
 	svc := rds.New(provider.sess, &aws.Config{Region: aws.String(provider.config.Region)})
 
 	for _, resource := range dbs.ResourceTagMappingList {
-		database, err := svc.DescribeDBInstancesWithContext(ctx, &rds.DescribeDBInstancesInput{ //nolint:contextcheck
+		database, err := svc.DescribeDBInstancesWithContext(ctx, &rds.DescribeDBInstancesInput{
 			DBInstanceIdentifier: resource.ResourceARN,
 		})
 		if err != nil {
@@ -236,7 +236,7 @@ func (provider *Provider) processDatabases(ctx context.Context) error {
 				continue
 			}
 
-			result, err := svc.StartDBInstanceWithContext(ctx, &rds.StartDBInstanceInput{ //nolint:contextcheck
+			result, err := svc.StartDBInstanceWithContext(ctx, &rds.StartDBInstanceInput{
 				DBInstanceIdentifier: database.DBInstances[0].DBInstanceIdentifier,
 			})
 			if err != nil {
@@ -253,7 +253,7 @@ func (provider *Provider) processDatabases(ctx context.Context) error {
 				continue
 			}
 
-			result, err := svc.StopDBInstanceWithContext(ctx, &rds.StopDBInstanceInput{ //nolint:contextcheck
+			result, err := svc.StopDBInstanceWithContext(ctx, &rds.StopDBInstanceInput{
 				DBInstanceIdentifier: database.DBInstances[0].DBInstanceIdentifier,
 			})
 			if err != nil {


### PR DESCRIPTION
add remote servers management, added new tab in dashboard "remote server", that contains all servers from Hetzner Cloud in project that corresponds token

this functionality has start/stop functions that manage this servers on this tab, all servers automatically switch off in evening, this can reduce bill from provider

main purpose this change - a dedicated server resources that can be used by developers in business time

add config this lines
```yaml
remoteServer:
  hetznertoken: "<token from hetzner cloud>"
```
Signed-off-by: Maksim Paskal <paskal.maksim@gmail.com>