### PR TITLE
handle context and interruption

### DIFF
--- a/e2e/api_test.go
+++ b/e2e/api_test.go
@@ -269,7 +269,7 @@ func TestDeleteClusterRole(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = environment.DeleteClusterRolesAndBindings()
+	err = environment.DeleteClusterRolesAndBindings(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/api/deleteALL.go
+++ b/pkg/api/deleteALL.go
@@ -46,7 +46,7 @@ func (e *Environment) DeleteALL(ctx context.Context) *DeleteALLResult {
 	}()
 
 	go func() {
-		deleteClusterRolesAndBindings <- e.DeleteClusterRolesAndBindings()
+		deleteClusterRolesAndBindings <- e.DeleteClusterRolesAndBindings(ctx)
 	}()
 
 	result := DeleteALLResult{


### PR DESCRIPTION
handle interruption signal, remove use operation context than `context.Background()`

Signed-off-by: Maksim Paskal <paskal.maksim@gmail.com>