### PR TITLE
add namespace description

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ e2e:
 	kubectl create ns ${test-namespace}
 	kubectl label namespace ${test-namespace} kubernetes-manager=true
 	kubectl label namespace ${test-namespace} test-kubernetes-manager=true
+	kubectl annotate namespace ${test-namespace} kubernetes-manager/description='{{ .Namespace }}'
 	kubectl -n ${test-namespace} apply -f ./e2e/kubernetes
 	kubectl -n ${test-namespace} wait --for=condition=available deployment --all --timeout=600s
 

--- a/e2e/api_test.go
+++ b/e2e/api_test.go
@@ -14,6 +14,7 @@ package api_test
 
 import (
 	"context"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -113,6 +114,10 @@ func TestPods(t *testing.T) {
 	}
 
 	environment = envieronments[0]
+
+	if environment.NamespaceDescription != os.Getenv("POD_NAMESPACE") {
+		t.Fatal("description must equals POD_NAMESPACE env")
+	}
 
 	err = checkLastScaleDate(environment)
 	if err != nil {

--- a/front/pages/_environmentID/info.vue
+++ b/front/pages/_environmentID/info.vue
@@ -17,6 +17,10 @@
       <pre v-else class="m-0">{{ environment }}</pre>
     </b-card>
 
+    <b-card v-if="environment.NamespaceDescription" class="mt-3" header="Description">
+      <pre>{{ environment.NamespaceDescription }}</pre>
+    </b-card>
+
     <b-card class="mt-3" header="Hosts">
       <ul v-if="environment.Hosts && environment.Hosts.length > 0">
         <li v-bind:key="index" v-for="(item, index) in environment.Hosts">
@@ -27,8 +31,7 @@
         deployed...</div>
     </b-card>
 
-    <b-card class="mt-3" header="Internal Hosts"
-      v-if="environment.HostsInternal && environment.HostsInternal.length > 0">
+    <b-card class="mt-3" header="Internal Hosts" v-if="environment.HostsInternal && environment.HostsInternal.length > 0">
       <WarningDisableMTLS />
       <ul>
         <li v-bind:key="index" v-for="(item, index) in environment.HostsInternal">

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysql v1.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleservers v1.0.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.0.0
+	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/aws/aws-sdk-go v1.44.228
 	github.com/gorilla/mux v1.8.0
 	github.com/hetznercloud/hcloud-go v1.41.0
@@ -33,6 +34,8 @@ require (
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.2.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v0.9.0 // indirect
+	github.com/Masterminds/goutils v1.1.1 // indirect
+	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
@@ -53,13 +56,16 @@ require (
 	github.com/gosimple/slug v1.9.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.2 // indirect
-	github.com/imdario/mergo v0.3.10 // indirect
+	github.com/huandu/xstrings v1.3.3 // indirect
+	github.com/imdario/mergo v0.3.11 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/mitchellh/copystructure v1.0.0 // indirect
+	github.com/mitchellh/reflectwalk v1.0.0 // indirect
 	github.com/moby/spdystream v0.2.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,12 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/HdrHistogram/hdrhistogram-go v1.0.1 h1:GX8GAYDuhlFQnI2fRDHQhTlkHMz8bEn0jTI6LJU0mpw=
 github.com/HdrHistogram/hdrhistogram-go v1.0.1/go.mod h1:BWJ+nMSHY3L41Zj7CA3uXnloDp7xxV0YvstAE7nKTaM=
+github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
+github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
+github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
+github.com/Masterminds/sprig v2.22.0+incompatible h1:z4yfnGrZ7netVz+0EDJ0Wi+5VZCSYp4Z0m2dk6cEM60=
+github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -199,9 +205,11 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hetznercloud/hcloud-go v1.41.0 h1:KJGFRRc68QiVu4PrEP5BmCQVveCP2CM26UGQUKGpIUs=
 github.com/hetznercloud/hcloud-go v1.41.0/go.mod h1:NaHg47L6C77mngZhwBG652dTAztYrsZ2/iITJKhQkHA=
+github.com/huandu/xstrings v1.3.3 h1:/Gcsuc1x8JVbJ9/rlye4xZnVAbEkGauT8lbebqcQws4=
+github.com/huandu/xstrings v1.3.3/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
-github.com/imdario/mergo v0.3.10 h1:6q5mVkdH/vYmqngx7kZQTjJ5HRsx+ImorDIEQ+beJgc=
-github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
+github.com/imdario/mergo v0.3.11 h1:3tnifQM4i+fbajXKBHXWEH+KvNHqojZ778UH75j3bGA=
+github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
@@ -245,6 +253,10 @@ github.com/maksim-paskal/sluglify v0.0.8 h1:i5OIkx1eDAd68au46t4sXJcDod1rINLB8oQa
 github.com/maksim-paskal/sluglify v0.0.8/go.mod h1:w9w+XyuMUr0fMOpgzUx0rGFTTP++VxR3fVl49lfa6ZY=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMKeZ+mmkFQ=
+github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
+github.com/mitchellh/reflectwalk v1.0.0 h1:9D+8oIskB4VJBN5SFlmc27fSlIBZaov1Wpk/IfikLNY=
+github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/pkg/api/startNewEnvironment.go
+++ b/pkg/api/startNewEnvironment.go
@@ -205,13 +205,13 @@ func NewEnvironment(ctx context.Context, id string, creator string) (*Environmen
 		return nil, errors.Wrap(err, "can not get clientset")
 	}
 
-	defaultMeta := config.Get().DeepCopy().NamespaceMeta
+	namespaceMeta := config.GetNamespaceMeta(idInfo.Namespace)
 
 	namespace := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        idInfo.Namespace,
-			Labels:      defaultMeta.Labels,
-			Annotations: defaultMeta.Annotations,
+			Labels:      namespaceMeta.Labels,
+			Annotations: namespaceMeta.Annotations,
 		},
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -69,6 +69,7 @@ const (
 	LabelUserLiked        = Namespace + "/user-liked"
 	LabelGitSyncOrigin    = Namespace + "/git-sync-origin"
 	LabelGitSyncBranch    = Namespace + "/git-sync-branch"
+	LabelDescription      = Namespace + "/description"
 
 	HeaderOwner = "X-Owner"
 )
@@ -180,6 +181,7 @@ func (p *ProjectProfile) GetProjectSelectedBranch(projectID int) string {
 }
 
 type NamespaceMeta struct {
+	Pattern     string
 	Labels      map[string]string
 	Annotations map[string]string
 }
@@ -276,7 +278,7 @@ type Type struct {
 	LogLevel                   *string `yaml:"logLevel"`
 	Links                      *Links  `yaml:"links"`
 	BatchEnabled               *bool
-	NamespaceMeta              *NamespaceMeta
+	NamespaceMeta              []*NamespaceMeta
 	DebugTemplates             []*Template
 	ExternalServicesTemplates  []*Template
 	ProjectProfiles            []*ProjectProfile
@@ -465,4 +467,20 @@ func GetKubernetesEndpointByName(name string) *KubernetesEndpoint {
 	}
 
 	return nil
+}
+
+func GetNamespaceMeta(namespace string) *NamespaceMeta {
+	for _, namespaceMeta := range config.DeepCopy().NamespaceMeta {
+		if len(namespaceMeta.Pattern) == 0 {
+			return namespaceMeta
+		} else if regexp.MustCompile(namespaceMeta.Pattern).Match([]byte(namespace)) {
+			return namespaceMeta
+		}
+	}
+
+	// if not found, return empty meta
+	return &NamespaceMeta{
+		Labels:      map[string]string{},
+		Annotations: map[string]string{},
+	}
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -43,14 +43,14 @@ func TestConfig(t *testing.T) {
 		t.Fatal("links in kubernetesendpoints should not contain empty string " + string(linksYaml))
 	}
 
-	test1 := config.Get().DeepCopy().NamespaceMeta.Labels
+	test1 := config.GetNamespaceMeta("").Labels
 
 	test1["test1"] = "test1"
 	if test1["environment"] != "dev" {
 		t.Fatal("test1 must have environment variable")
 	}
 
-	test2 := config.Get().NamespaceMeta.Labels
+	test2 := config.GetNamespaceMeta("").Labels
 
 	test2["test2"] = "test2"
 	if test2["test1"] == "test1" {

--- a/pkg/config/testdata/config_test.yaml
+++ b/pkg/config/testdata/config_test.yaml
@@ -13,5 +13,5 @@ kubernetesendpoints:
 - name: default
 
 namespacemeta:
-  labels:
+- labels:
     environment: dev

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -22,6 +22,7 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/Masterminds/sprig"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
@@ -104,7 +105,7 @@ func (l JaegerLogs) Infof(msg string, args ...interface{}) {
 }
 
 func GetTemplatedResult(text string, obj interface{}) ([]byte, error) {
-	t, err := template.New("getTemplatedString").Parse(text)
+	t, err := template.New("getTemplatedString").Funcs(sprig.FuncMap()).Parse(text)
 	if err != nil {
 		return nil, errors.Wrap(err, "error parsing template")
 	}


### PR DESCRIPTION
_CHANGES_

display Description field in environment info page, this description you can add with annotations (string can contain golang templated string)
```
kubectl annotate namespace test-namespace kubernetes-manager/description='{{ .Namespace }}'
```

`namespacemeta` in config is now array!! now you add different meta for all namespaces with `pattern` field
```yaml
namespacemeta:
- pattern: '.+'
  labels:
    environment: dev
```