### PR TITLE
do not load dropdown when default value set

### DIFF
--- a/front/components/DropDown.vue
+++ b/front/components/DropDown.vue
@@ -28,6 +28,11 @@ export default {
   watch: {
     value: function () {
       this.selected = this.value;
+    },
+    search: function () {
+      if (this.default && this.search == "") {
+        this.reload();
+      }
     }
   },
   mounted() {
@@ -45,6 +50,9 @@ export default {
     // load default search value
     if (this.default) {
       this.search = this.default;
+      // don't load results if default is set
+      this.data = [this.default];
+      this.isLoaded = true;
     }
   },
   data() {


### PR DESCRIPTION
loading list with default value take a lot of time, dropdown will show you default value if set - for loading all list - you must to clear search text