### PR TITLE
add variables on pipeline start

### DIFF
--- a/pkg/api/getUser.go
+++ b/pkg/api/getUser.go
@@ -1,0 +1,32 @@
+/*
+Copyright paskal.maksim@gmail.com
+Licensed under the Apache License, Version 2.0 (the "License")
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package api
+
+import (
+	"context"
+
+	"github.com/maksim-paskal/kubernetes-manager/pkg/telemetry"
+	"github.com/maksim-paskal/kubernetes-manager/pkg/types"
+)
+
+func (e *Environment) GetUser(ctx context.Context) string {
+	ctx, span := telemetry.Start(ctx, "api.GetUser")
+	defer span.End()
+
+	security, ok := ctx.Value(types.ContextSecurityKey).(types.ContextSecurity)
+	if ok {
+		return security.Owner
+	}
+
+	return ""
+}

--- a/pkg/api/saveNamespaceMeta.go
+++ b/pkg/api/saveNamespaceMeta.go
@@ -54,5 +54,14 @@ func (e *Environment) SaveNamespaceMeta(ctx context.Context, annotation map[stri
 		return err
 	}
 
+	// if OK - update labels and annotations in Environment
+	for key, value := range annotation {
+		e.NamespaceAnnotations[key] = value
+	}
+
+	for key, value := range labels {
+		e.NamespaceLabels[key] = value
+	}
+
 	return nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -52,6 +52,7 @@ const (
 	LabelScaleDownDelayShort = "scaleDownDelay"
 
 	Namespace             = "kubernetes-manager"
+	AnnotationPrefix      = Namespace + "/"
 	FilterLabels          = Namespace + "=true"
 	LabelType             = Namespace + "/type"
 	LabelScaleDownDelay   = Namespace + "/" + LabelScaleDownDelayShort


### PR DESCRIPTION
add namespace annotations as pipeline variables, example:
```
K8SMNG_PROFILE=test
K8SMNG_SCALEDOWNDELAY=2024-03-06T02:10:10Z
K8SMNG_PROJECT_2=main
K8SMNG_PROJECT_3=main
K8SMNG_PROJECT_4=main
K8SMNG_LASTSCALEDATE=2024-03-05T16:10:10Z
K8SMNG_PROJECT_1=IT-424.move_to_pod_admission_controller
```