### PR TITLE
feat(front): add select installed branches and clean selection buttons

### DIFF
--- a/front/components/GitlabProjects.vue
+++ b/front/components/GitlabProjects.vue
@@ -16,6 +16,10 @@
         <b-button variant="outline-primary" @click="resetSelection()">Reset selection</b-button>
         <b-button variant="outline-primary" @click="showShareDialog()">Share settings</b-button>
       </div>
+      <div v-else>
+        <b-button variant="outline-primary" @click="selectAllFromInstalled()">Select installed branches</b-button>
+        <b-button variant="outline-primary" @click="cleanSelection()">Clean selection</b-button>
+      </div>
       <b-table striped hover :items="data" :fields="tableFields">
         <template #cell(Service)="data">
           <b-button title="delete service from namespace" v-if="podInfo" :disabled="data.item.GitBranch ? false : true"
@@ -158,6 +162,16 @@ export default {
     selectAllFromMain() {
       this.data.forEach(async (row) => {
         row.Deploy = row.DefaultBranch
+      });
+    },
+    selectAllFromInstalled() {
+      this.data.forEach((row) => {
+        row.Deploy = row.GitBranch;
+      });
+    },
+    cleanSelection() {
+      this.data.forEach((el) => {
+        el.Deploy = "";
       });
     },
     resetSelection() {


### PR DESCRIPTION
## Summary
- Add "Select installed branches" button that populates the Deploy field from the currently installed `GitBranch` for each service
- Add "Clean selection" button that clears all Deploy fields
- Both buttons are shown when no project profile is set (`v-else` branch)

## Test plan
- [ ] Open a namespace view without a project profile and verify the two new buttons appear
- [ ] Click "Select installed branches" and verify each row's Deploy is set to its installed branch
- [ ] Click "Clean selection" and verify all Deploy fields are cleared