### PR TITLE
feat(front): skip beta and testing services in select-all action

### DIFF
--- a/front/components/GitlabProjects.vue
+++ b/front/components/GitlabProjects.vue
@@ -161,6 +161,9 @@ export default {
   methods: {
     selectAllFromMain() {
       this.data.forEach(async (row) => {
+        // ignore beta/testing services
+        if (["(beta)", "(testing)"].some(tag => row.Description.toLowerCase().includes(tag))) return;
+
         row.Deploy = row.DefaultBranch
       });
     },


### PR DESCRIPTION
## Summary
- Ignore services whose description contains `(beta)` or `(testing)` tags when "Select All from Main" is clicked
- Prevents unintended deployments to non-production services

## Test plan
- [x] Click "Select All from Main" and verify beta/testing services are not selected
- [x] Verify normal services are still selected as expected